### PR TITLE
Add initial support for AppImage building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dev.gen
 localnet.json
 lotus-daemon.log
 lotus-miner.log
+AppDir/
+*.AppImage
+appimage-build/

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,0 +1,70 @@
+version: 1
+AppDir:
+  path: ./AppDir
+  app_info:
+    id: io.filecoin.boost
+    name: Boost
+    version: latest
+    exec: usr/bin/boost
+    exec_args: $@
+  apt:
+    arch: amd64
+    allow_unauthenticated: true
+    sources:
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal main restricted
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal universe
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-updates universe
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal multiverse
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-updates multiverse
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted
+        universe multiverse
+    - sourceline: deb http://security.ubuntu.com/ubuntu focal-security main restricted
+    - sourceline: deb http://security.ubuntu.com/ubuntu focal-security universe
+    - sourceline: deb http://security.ubuntu.com/ubuntu focal-security multiverse
+    - sourceline: deb https://cli-assets.heroku.com/apt ./
+    - sourceline: deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu focal main
+    - sourceline: deb http://ppa.launchpad.net/git-core/ppa/ubuntu focal main
+    - sourceline: deb http://archive.canonical.com/ubuntu focal partner
+    include:
+    - ocl-icd-libopencl1
+    - libhwloc15
+    exclude: []
+  files:
+    include:
+    - /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+#    - /usr/lib/x86_64-linux-gnu/libpthread-2.31.so
+    - /usr/lib/x86_64-linux-gnu/libm-2.31.so
+    - /usr/lib/x86_64-linux-gnu/libdl-2.31.so
+    - /usr/lib/x86_64-linux-gnu/libc-2.31.so
+    - /usr/lib/x86_64-linux-gnu/libudev.so.1.6.17
+    exclude:
+    - usr/share/man
+    - usr/share/doc/*/README.*
+    - usr/share/doc/*/changelog.*
+    - usr/share/doc/*/NEWS.*
+    - usr/share/doc/*/TODO.*
+  test:
+    fedora:
+      image: appimagecrafters/tests-env:fedora-30
+      command: ./AppRun
+      use_host_x: false
+    debian:
+      image: appimagecrafters/tests-env:debian-stable
+      command: ./AppRun
+      use_host_x: false
+    arch:
+      image: appimagecrafters/tests-env:archlinux-latest
+      command: ./AppRun
+      use_host_x: false
+    centos:
+      image: appimagecrafters/tests-env:centos-7
+      command: ./AppRun
+      use_host_x: false
+    ubuntu:
+      image: appimagecrafters/tests-env:ubuntu-xenial
+      command: ./AppRun
+      use_host_x: false
+AppImage:
+  arch: x86_64
+

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,13 @@ build: react build-go
 calibnet: react calibnet-go
 .PHONY: calibnet
 
+appimage: boost
+	rm -rf appimage-builder-cache || true
+	rm -rf AppDir/ || true
+	mkdir -p AppDir/usr/bin
+	cp ./boost AppDir/usr/bin/
+	appimage-builder --skip-test
+
 install: install-boost install-devnet
 
 install-boost:


### PR DESCRIPTION
`make appimage` now builds boost and packages (only) the boost binary into an AppImage using appimage-builder similarly to lotus.

Builds sadly only on apt-based distros.